### PR TITLE
Add swagger documentation page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,8 @@
         <mockito.version>2.7.22</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>
         <restassured.version>3.0.3</restassured.version>
+        <swagger.version>1.5.10</swagger.version>
+        <swagger.ui.tag>3.0.6</swagger.ui.tag>
         <mainClass>org.vahid.SorenSubscriberApplication</mainClass>
     </properties>
 
@@ -47,6 +49,11 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-assets</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
@@ -75,9 +82,22 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-jersey2-jaxrs</artifactId>
+            <version>${swagger.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>jersey-container-servlet-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -168,6 +188,57 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- swagger-ui static site download -->
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <id>swagger-ui</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://github.com/swagger-api/swagger-ui/archive/v${swagger.ui.tag}.tar.gz
+                            </url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- swagger-ui copy download into resources -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/src/main/resources/swagger-ui</outputDirectory>
+                            <resources>
+                                <resource>
+                                  <directory>
+                                      ${project.build.directory}/swagger-ui-${swagger.ui.tag}/dist
+                                  </directory>
+                                  <filtering>true</filtering>
+                                  <!--
+                                  <excludes>
+                                    <exclude>index.html</exclude>
+                                  </excludes>
+                                  -->
+                                </resource>
+                            </resources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/org/vahid/SorenSubscriberApplication.java
+++ b/src/main/java/org/vahid/SorenSubscriberApplication.java
@@ -1,19 +1,25 @@
 package org.vahid;
 
+import static org.vahid.util.Constants.APPLICATION_NAME;
+import static org.vahid.util.Constants.DATABASE_TYPE;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import io.dropwizard.Application;
-import io.dropwizard.jdbi.DBIFactory;
-import io.dropwizard.setup.Bootstrap;
-import io.dropwizard.setup.Environment;
+
 import org.skife.jdbi.v2.DBI;
 import org.vahid.db.SorenSubscriberDAO;
 import org.vahid.health.SubscriberHealthCheck;
 import org.vahid.resources.SubscriberResource;
 
-import static org.vahid.util.Constants.DATABASE_TYPE;
-import static org.vahid.util.Constants.APPLICATION_NAME;
+import io.dropwizard.Application;
+import io.dropwizard.assets.AssetsBundle;
+import io.dropwizard.jdbi.DBIFactory;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.listing.ApiListingResource;
 
 
 public class SorenSubscriberApplication extends Application<SorenSubscriberConfiguration> {
@@ -30,6 +36,7 @@ public class SorenSubscriberApplication extends Application<SorenSubscriberConfi
     @Override
     public void initialize(final Bootstrap<SorenSubscriberConfiguration> bootstrap) {
         // TODO: application initialization
+        bootstrap.addBundle(new AssetsBundle("/swagger-ui", "/docs", "index.html"));
     }
 
     @Override
@@ -45,11 +52,22 @@ public class SorenSubscriberApplication extends Application<SorenSubscriberConfi
             }
         });
 
+        // Swagger doc endpoint
+        environment.jersey().register(new ApiListingResource());
+
         // Health Check registration
         environment.jersey().register(injector.getInstance(SubscriberHealthCheck.class));
 
         // Resources registration
         environment.jersey().register(injector.getInstance(SubscriberResource.class));
+
+        environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        BeanConfig config = new BeanConfig();
+        config.setTitle("Swagger sample app");
+        config.setVersion("1.0.0");
+        config.setResourcePackage("org.vahid.resources");
+        config.setScan(true);
     }
 
 }

--- a/src/main/java/org/vahid/resources/SubscriberResource.java
+++ b/src/main/java/org/vahid/resources/SubscriberResource.java
@@ -1,18 +1,37 @@
 package org.vahid.resources;
 
+import static org.vahid.util.Constants.BOOK_ENTITY;
+import static org.vahid.util.Constants.CATEGORY_ENTITY;
+import static org.vahid.util.Constants.RESOURCE_NOT_OK;
+import static org.vahid.util.Constants.SUBSCRIBER_ENTITY;
+
 import com.google.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.vahid.api.*;
+import org.vahid.api.Book;
+import org.vahid.api.Category;
+import org.vahid.api.FavoriteBooks;
+import org.vahid.api.MapEntity;
+import org.vahid.api.NewsLetter;
+import org.vahid.api.ResponseStatus;
+import org.vahid.api.Subscriber;
 import org.vahid.services.SubscriberService;
-import static org.vahid.util.Constants.*;
 
-import javax.validation.Valid;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 
 /**
  * Created by vahid (@vahid_r)
@@ -21,6 +40,7 @@ import java.util.List;
 
 
 @Path("/api/v1")
+@Api(value = "/api/v1", description = "Subscriber endpoints")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class SubscriberResource {
@@ -31,6 +51,9 @@ public class SubscriberResource {
 
     @GET
     @Path("/ping")
+    @ApiOperation(
+        value = "Request a pong.",
+        response = Response.class)
     public Response ping() {
         log.debug("PING called !!");
         return Response.ok().entity("PONG!!").build();
@@ -38,6 +61,9 @@ public class SubscriberResource {
 
     @POST
     @Path("/categories")
+    @ApiOperation(
+        value = "Create a new category",
+        response = Response.class)
     public Response createCategory(@Valid Category category) {
         log.debug("category in Resource: {}", category.toString());
         boolean isSuccessful = subscriberService.createCategory(category);
@@ -50,6 +76,9 @@ public class SubscriberResource {
 
     @POST
     @Path("/books")
+    @ApiOperation(
+        value = "Create a new book",
+        response = Response.class)
     public Response createBook(@Valid Book book) {
         boolean isSuccessful = subscriberService.createBook(book);
         if (isSuccessful) {
@@ -61,6 +90,9 @@ public class SubscriberResource {
 
     @POST
     @Path("/subscribers")
+    @ApiOperation(
+        value = "Create a new subscriber",
+        response = Response.class)
     public Response createSubscriber(@Valid Subscriber subscriber) {
         boolean isSuccessful = subscriberService.createSubscriber(subscriber);
         if (isSuccessful) {
@@ -72,6 +104,9 @@ public class SubscriberResource {
 
     @GET
     @Path("/newsletters")
+    @ApiOperation(
+        value = "Get a newsletter",
+        response = Response.class)
     public Response getNewsLetters() {
         List<NewsLetter> newsLetters = new ArrayList<>();
         List<MapEntity> subscribersWithCats = subscriberService.getSubscribersWithCats();
@@ -85,6 +120,4 @@ public class SubscriberResource {
 
         return Response.ok(newsLetters).build();
     }
-
-
 }


### PR DESCRIPTION
I've been messing around with swagger and dropwizard recently and took your project as an opportunity to practice integrating the two. This adds a new endpoint:
```
    POST    /api/v1/books (org.vahid.resources.SubscriberResource)
    POST    /api/v1/categories (org.vahid.resources.SubscriberResource)
    GET     /api/v1/newsletters (org.vahid.resources.SubscriberResource)
    GET     /api/v1/ping (org.vahid.resources.SubscriberResource)
    POST    /api/v1/subscribers (org.vahid.resources.SubscriberResource)
--> GET     /swagger.{type:json|yaml} (io.swagger.jaxrs.listing.ApiListingResource)
```

And a static page hosted at `/docs` which can display the data like this: `http://localhost:8080/docs/?url=../swagger.json`

![screen shot 2017-08-02 at 10 13 05 am](https://user-images.githubusercontent.com/125509/28877725-37e3a2bc-776b-11e7-87af-dc10ac88e23d.png)
